### PR TITLE
Disable flaky tests

### DIFF
--- a/integration-tests/grpc-hibernate/src/test/java/com/example/grpc/hibernate/BlockingRawTest.java
+++ b/integration-tests/grpc-hibernate/src/test/java/com/example/grpc/hibernate/BlockingRawTest.java
@@ -1,7 +1,10 @@
 package com.example.grpc.hibernate;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.junit.QuarkusTest;
 
+@Disabled("Flaky, as soon as it compiles we are good in this separate repo")
 @QuarkusTest
 public class BlockingRawTest extends BlockingRawTestBase {
 }

--- a/integration-tests/grpc-hibernate/src/test/java/com/example/grpc/hibernate/VertxBlockingRawTest.java
+++ b/integration-tests/grpc-hibernate/src/test/java/com/example/grpc/hibernate/VertxBlockingRawTest.java
@@ -1,9 +1,12 @@
 package com.example.grpc.hibernate;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
+@Disabled("Flaky, as soon as it compiles we are good in this separate repo")
 @QuarkusTest
 @TestProfile(VertxGRPCTestProfile.class)
 public class VertxBlockingRawTest extends BlockingRawTestBase {


### PR DESCRIPTION
We are observing one flaky tests:

https://github.com/quarkiverse/quarkus-grpc-zero/actions/runs/17323176205/job/49180903500?pr=4

https://github.com/quarkiverse/quarkus-grpc-zero/actions/runs/17323169887/job/49180879840?pr=2

it's not a concern specific to this repository, as long as everything compiles we are good.
Additionally the current integration tests are taking forever in CI, we might need to remove some as them.
The grpc implementations are already tested in Quarkus and they don't add much in terms of coverage here.