### PR TITLE
feat: detect duplicate proto types by descriptor FQN

### DIFF
--- a/codegen/src/main/java/io/quarkiverse/grpc/codegen/GrpcZeroCodeGen.java
+++ b/codegen/src/main/java/io/quarkiverse/grpc/codegen/GrpcZeroCodeGen.java
@@ -6,7 +6,6 @@ import static java.lang.Boolean.TRUE;
 import static java.nio.file.Files.copy;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -169,27 +168,7 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
 
                 var protobuf = Protobuf.builder().withWorkdir(workdir).build();
 
-                for (String protoFile : protoFiles) {
-                    try (InputStream is = Files.newInputStream(Path.of(protoFile))) {
-                        Files.copy(is, workdir.resolve(Path.of(protoFile).getFileName().toString()),
-                                StandardCopyOption.REPLACE_EXISTING);
-                    }
-
-                    log.info("resolving proto file: " + protoFile);
-                    var protoName = realitivizeProtoFile(protoFile, protoDirs);
-                    log.info("final proto name: " + protoName);
-
-                    try {
-                        descriptorSetBuilder.addAllFile(protobuf.getDescriptors(List.of(protoName)).getFileList());
-                    } catch (RuntimeException e) {
-                        throw new CodeGenException(
-                                "Grpc Zero failed while parsing proto '" + protoName + "' (source: " + protoFile + "). "
-                                        + "This is commonly caused by malformed proto syntax, unresolved imports, or duplicated "
-                                        + "merged content in a single file.",
-                                e);
-                    }
-                    requestBuilder.addFileToGenerate(protoName);
-                }
+                processProtoFiles(protoFiles, protoDirs, protobuf, descriptorSetBuilder, requestBuilder);
 
                 // Load the previously generated descriptor
                 DescriptorProtos.FileDescriptorSet descriptorSet = descriptorSetBuilder.build();
@@ -197,7 +176,7 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
                 // Add all FileDescriptorProto entries from the descriptor set
                 // and all from dependencies
                 try {
-                    resolveDependencies(protobuf, descriptorSet, requestBuilder);
+                    resolveDependencies(descriptorSet, requestBuilder);
                 } catch (RuntimeException e) {
                     throw new CodeGenException(
                             "Grpc Zero failed while resolving transitive proto dependencies. "
@@ -250,25 +229,52 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
         return false;
     }
 
-    public static boolean isInSubtree(Path baseDir, Path candidate) {
-        Path base = baseDir.toAbsolutePath().normalize();
-        Path cand = candidate.toAbsolutePath().normalize();
+    void processProtoFiles(List<String> protoFiles, Set<String> protoDirs,
+            Protobuf protobuf, DescriptorProtos.FileDescriptorSet.Builder descriptorSetBuilder,
+            PluginProtos.CodeGeneratorRequest.Builder requestBuilder) throws CodeGenException {
 
-        return cand.startsWith(base);
+        ProtoTypeConflictDetector conflictDetector = new ProtoTypeConflictDetector();
+        Set<String> alreadyRequested = new LinkedHashSet<>();
+
+        for (String protoFile : protoFiles) {
+            log.info("resolving proto file: " + protoFile);
+            var protoName = relativizeProtoFile(protoFile, protoDirs);
+            log.info("final proto name: " + protoName);
+
+            DescriptorProtos.FileDescriptorSet fileDescSet = loadDescriptorSet(protobuf, protoName, protoFile);
+
+            boolean allDuplicate = conflictDetector.checkAndRecord(fileDescSet, protoFile);
+
+            if (allDuplicate && alreadyRequested.contains(protoName)) {
+                log.infof("Skipping duplicate proto file (all types already resolved): %s", protoFile);
+                continue;
+            }
+
+            alreadyRequested.add(protoName);
+            descriptorSetBuilder.addAllFile(fileDescSet.getFileList());
+            requestBuilder.addFileToGenerate(protoName);
+        }
     }
 
-    // TODO: verify is all this dance can be simplified somehow ...
-    private static String realitivizeProtoFile(String protoFile, Set<String> protoDir) {
-        Path protoFilePath = Path.of(protoFile);
-        for (String dir : protoDir) {
-            try {
-                if (isInSubtree(Path.of(dir), protoFilePath)) {
-                    Path base = Path.of(dir).toAbsolutePath().normalize();
-                    Path file = protoFilePath.toAbsolutePath().normalize();
-                    return base.relativize(file).toString();
-                }
-            } catch (IllegalArgumentException e) {
-                // cannot be relativized, skip
+    private static DescriptorProtos.FileDescriptorSet loadDescriptorSet(Protobuf protobuf, String protoName,
+            String protoFile) throws CodeGenException {
+        try {
+            return protobuf.getDescriptors(List.of(protoName));
+        } catch (RuntimeException e) {
+            throw new CodeGenException(
+                    "Grpc Zero failed while parsing proto '" + protoName + "' (source: " + protoFile + "). "
+                            + "This is commonly caused by malformed proto syntax, unresolved imports, or duplicated "
+                            + "merged content in a single file.",
+                    e);
+        }
+    }
+
+    private static String relativizeProtoFile(String protoFile, Set<String> protoDirs) {
+        Path protoFilePath = Path.of(protoFile).toAbsolutePath().normalize();
+        for (String dir : protoDirs) {
+            Path baseDir = Path.of(dir).toAbsolutePath().normalize();
+            if (protoFilePath.startsWith(baseDir)) {
+                return baseDir.relativize(protoFilePath).toString().replace("\\", "/");
             }
         }
         return protoFilePath.getFileName().toString();
@@ -285,11 +291,11 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
         }
     }
 
-    private static void resolveDependencies(Protobuf protobuf,
-            DescriptorProtos.FileDescriptorSet descriptorSet, PluginProtos.CodeGeneratorRequest.Builder requestBuilder)
+    private static void resolveDependencies(DescriptorProtos.FileDescriptorSet descriptorSet,
+            PluginProtos.CodeGeneratorRequest.Builder requestBuilder)
             throws CodeGenException {
         // Use protobuf4j's buildFileDescriptors to resolve all dependencies
-        List<Descriptors.FileDescriptor> fileDescriptors = protobuf.buildFileDescriptors(descriptorSet);
+        List<Descriptors.FileDescriptor> fileDescriptors = Protobuf.buildFileDescriptors(descriptorSet);
 
         // Collect all file descriptors (including transitive dependencies) into a new descriptor set
         DescriptorProtos.FileDescriptorSet.Builder allDescriptorsBuilder = DescriptorProtos.FileDescriptorSet.newBuilder();
@@ -306,7 +312,7 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
     }
 
     public static void copyDirectory(final Path source, final Path target) throws IOException {
-        java.nio.file.Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
+        java.nio.file.Files.walkFileTree(source, new SimpleFileVisitor<>() {
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
                 if (java.nio.file.Files.isSymbolicLink(dir)) {
                     return FileVisitResult.SKIP_SUBTREE;
@@ -316,8 +322,7 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
                     Path directory = target.resolve(relative).normalize();
                     if (!directory.toString().equals("/")) {
                         FileAttribute<?>[] attributes = new FileAttribute[0];
-                        PosixFileAttributeView attributeView = (PosixFileAttributeView) java.nio.file.Files
-                                .getFileAttributeView(dir, PosixFileAttributeView.class);
+                        PosixFileAttributeView attributeView = Files.getFileAttributeView(dir, PosixFileAttributeView.class);
                         if (attributeView != null) {
                             Set<PosixFilePermission> permissions = attributeView.readAttributes().permissions();
                             FileAttribute<Set<PosixFilePermission>> attribute = PosixFilePermissions
@@ -397,7 +402,7 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
         boolean scanAll = "all".equalsIgnoreCase(scanDependencies);
 
         List<String> dependenciesToScan = Arrays.stream(scanDependencies.split(",")).map(String::trim)
-                .collect(Collectors.toList());
+                .toList();
 
         ApplicationModel appModel = context.applicationModel();
         List<Path> protoFilesFromDependencies = new ArrayList<>();
@@ -469,7 +474,7 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
 
         boolean scanAll = "all".equals(scanForImports.toLowerCase(Locale.getDefault()));
         List<String> dependenciesToScan = Arrays.stream(scanForImports.split(",")).map(String::trim)
-                .collect(Collectors.toList());
+                .toList();
 
         Set<String> importDirectories = new HashSet<>();
         ApplicationModel appModel = context.applicationModel();

--- a/codegen/src/main/java/io/quarkiverse/grpc/codegen/ProtoTypeConflictDetector.java
+++ b/codegen/src/main/java/io/quarkiverse/grpc/codegen/ProtoTypeConflictDetector.java
@@ -1,0 +1,94 @@
+package io.quarkiverse.grpc.codegen;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+
+import com.google.protobuf.DescriptorProtos;
+
+import io.quarkus.bootstrap.prebuild.CodeGenException;
+
+/**
+ * Tracks protobuf type fully qualified names across proto files and detects conflicts.
+ * <p>
+ * Identical types (same FQN, same descriptor bytes) from multiple sources are treated
+ * as benign duplicates. Different types sharing the same FQN are rejected with a
+ * clear error naming both source files.
+ * <p>
+ * Comparisons use compiled descriptor bytes, so cosmetic differences like comments
+ * and whitespace do not cause false positives.
+ */
+class ProtoTypeConflictDetector {
+
+    private static final Logger log = Logger.getLogger(ProtoTypeConflictDetector.class);
+
+    private final Map<String, byte[]> seenTypeBytes = new LinkedHashMap<>();
+    private final Map<String, String> seenTypeSource = new LinkedHashMap<>();
+
+    /**
+     * Check all types declared in the given descriptor set against previously seen types.
+     *
+     * @param fileDescSet the parsed descriptor set for a single proto file
+     * @param sourceProtoFile the on-disk path of the proto file (for error messages)
+     * @return true if every type in the set was already seen with identical bytes
+     * @throws CodeGenException if any type conflicts with a previously seen definition
+     */
+    boolean checkAndRecord(DescriptorProtos.FileDescriptorSet fileDescSet, String sourceProtoFile)
+            throws CodeGenException {
+        boolean allDuplicate = true;
+        for (DescriptorProtos.FileDescriptorProto file : fileDescSet.getFileList()) {
+            String prefix = file.getPackage().isEmpty() ? "." : "." + file.getPackage() + ".";
+            allDuplicate &= checkFile(file, prefix, sourceProtoFile);
+        }
+        return allDuplicate;
+    }
+
+    private boolean checkFile(DescriptorProtos.FileDescriptorProto file, String prefix,
+            String sourceProtoFile) throws CodeGenException {
+        boolean allDup = true;
+        for (DescriptorProtos.DescriptorProto message : file.getMessageTypeList()) {
+            allDup &= checkMessage(message, prefix, sourceProtoFile);
+        }
+        for (DescriptorProtos.EnumDescriptorProto e : file.getEnumTypeList()) {
+            allDup &= checkType(prefix + e.getName(), e.toByteArray(), sourceProtoFile);
+        }
+        for (DescriptorProtos.ServiceDescriptorProto s : file.getServiceList()) {
+            allDup &= checkType(prefix + s.getName(), s.toByteArray(), sourceProtoFile);
+        }
+        return allDup;
+    }
+
+    private boolean checkMessage(DescriptorProtos.DescriptorProto message, String parentFqn,
+            String sourceProtoFile) throws CodeGenException {
+        String fqn = parentFqn + message.getName();
+        boolean dup = checkType(fqn, message.toByteArray(), sourceProtoFile);
+
+        String childPrefix = fqn + ".";
+        for (DescriptorProtos.DescriptorProto nested : message.getNestedTypeList()) {
+            dup &= checkMessage(nested, childPrefix, sourceProtoFile);
+        }
+        for (DescriptorProtos.EnumDescriptorProto nestedEnum : message.getEnumTypeList()) {
+            dup &= checkType(childPrefix + nestedEnum.getName(), nestedEnum.toByteArray(), sourceProtoFile);
+        }
+        return dup;
+    }
+
+    private boolean checkType(String fqn, byte[] bytes, String sourceProtoFile) throws CodeGenException {
+        byte[] existing = seenTypeBytes.get(fqn);
+        if (existing == null) {
+            seenTypeBytes.put(fqn, bytes);
+            seenTypeSource.put(fqn, sourceProtoFile);
+            return false;
+        }
+        if (!Arrays.equals(existing, bytes)) {
+            throw new CodeGenException(
+                    "Conflicting proto definitions for " + fqn
+                            + " first declared in " + seenTypeSource.get(fqn)
+                            + ", redefined differently in " + sourceProtoFile);
+        }
+        log.debugf("Duplicate type %s from %s matches existing from %s", fqn, sourceProtoFile, seenTypeSource.get(fqn));
+        return true;
+    }
+}

--- a/codegen/src/test/java/io/quarkiverse/grpc/codegen/ProcessProtoFilesTest.java
+++ b/codegen/src/test/java/io/quarkiverse/grpc/codegen/ProcessProtoFilesTest.java
@@ -1,0 +1,135 @@
+package io.quarkiverse.grpc.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.compiler.PluginProtos;
+
+import io.quarkus.bootstrap.prebuild.CodeGenException;
+import io.roastedroot.protobuf4j.v4.Protobuf;
+import io.roastedroot.zerofs.Configuration;
+import io.roastedroot.zerofs.ZeroFs;
+
+class ProcessProtoFilesTest {
+
+    @TempDir
+    Path tempDir;
+
+    private void writeProto(Path dir, String filename, String content) throws Exception {
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve(filename), content, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void differentProtosAreProcessed() throws Exception {
+        // Two distinct proto files with different FQNs in the same directory
+        Path protoDir = tempDir.resolve("protos");
+        writeProto(protoDir, "a.proto",
+                "syntax = \"proto3\";\npackage p.a;\nmessage A { string x = 1; }\n");
+        writeProto(protoDir, "b.proto",
+                "syntax = \"proto3\";\npackage p.b;\nmessage B { string y = 1; }\n");
+
+        List<String> protoFiles = List.of(
+                protoDir.resolve("a.proto").toAbsolutePath().toString(),
+                protoDir.resolve("b.proto").toAbsolutePath().toString());
+        Set<String> protoDirs = new LinkedHashSet<>(List.of(protoDir.toAbsolutePath().toString()));
+
+        try (FileSystem fs = ZeroFs.newFileSystem(
+                Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
+            Path workdir = fs.getPath(".");
+            GrpcZeroCodeGen.copyDirectory(protoDir, workdir);
+            Protobuf protobuf = Protobuf.builder().withWorkdir(workdir).build();
+
+            DescriptorProtos.FileDescriptorSet.Builder dsBuild = DescriptorProtos.FileDescriptorSet.newBuilder();
+            PluginProtos.CodeGeneratorRequest.Builder reqBuild = PluginProtos.CodeGeneratorRequest.newBuilder();
+
+            GrpcZeroCodeGen codegen = new GrpcZeroCodeGen();
+            assertDoesNotThrow(() -> codegen.processProtoFiles(protoFiles, protoDirs, protobuf, dsBuild, reqBuild));
+
+            assertEquals(2, reqBuild.getFileToGenerateCount());
+        }
+    }
+
+    @Test
+    void sameFqnDifferentShapeFailsFast() throws Exception {
+        // Two proto files declaring the same FQN with different field types
+        Path protoDir = tempDir.resolve("protos");
+        writeProto(protoDir, "first.proto",
+                "syntax = \"proto3\";\npackage demo;\nmessage Foo { string a = 1; }\n");
+        writeProto(protoDir, "second.proto",
+                "syntax = \"proto3\";\npackage demo;\nmessage Foo { int32 a = 1; }\n");
+
+        List<String> protoFiles = List.of(
+                protoDir.resolve("first.proto").toAbsolutePath().toString(),
+                protoDir.resolve("second.proto").toAbsolutePath().toString());
+        Set<String> protoDirs = new LinkedHashSet<>(List.of(protoDir.toAbsolutePath().toString()));
+
+        try (FileSystem fs = ZeroFs.newFileSystem(
+                Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
+            Path workdir = fs.getPath(".");
+            GrpcZeroCodeGen.copyDirectory(protoDir, workdir);
+            Protobuf protobuf = Protobuf.builder().withWorkdir(workdir).build();
+
+            DescriptorProtos.FileDescriptorSet.Builder dsBuild = DescriptorProtos.FileDescriptorSet.newBuilder();
+            PluginProtos.CodeGeneratorRequest.Builder reqBuild = PluginProtos.CodeGeneratorRequest.newBuilder();
+
+            GrpcZeroCodeGen codegen = new GrpcZeroCodeGen();
+            CodeGenException ex = assertThrows(CodeGenException.class,
+                    () -> codegen.processProtoFiles(protoFiles, protoDirs, protobuf, dsBuild, reqBuild));
+
+            assertTrue(ex.getMessage().contains(".demo.Foo"),
+                    "Should name the conflicting FQN, got: " + ex.getMessage());
+        }
+    }
+
+    @Test
+    void identicalDuplicateIsDeduped() throws Exception {
+        // Same proto content contributed by two different source directories
+        // (simulates the same dependency appearing twice)
+        Path dirA = tempDir.resolve("src-a");
+        Path dirB = tempDir.resolve("src-b");
+
+        String content = "syntax = \"proto3\";\npackage demo;\nmessage Foo { string a = 1; }\n";
+        writeProto(dirA, "demo.proto", content);
+        writeProto(dirB, "demo.proto", content);
+
+        List<String> protoFiles = List.of(
+                dirA.resolve("demo.proto").toAbsolutePath().toString(),
+                dirB.resolve("demo.proto").toAbsolutePath().toString());
+        Set<String> protoDirs = new LinkedHashSet<>(List.of(
+                dirA.toAbsolutePath().toString(),
+                dirB.toAbsolutePath().toString()));
+
+        try (FileSystem fs = ZeroFs.newFileSystem(
+                Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
+            Path workdir = fs.getPath(".");
+            for (String dir : protoDirs) {
+                GrpcZeroCodeGen.copyDirectory(Path.of(dir), workdir);
+            }
+            Protobuf protobuf = Protobuf.builder().withWorkdir(workdir).build();
+
+            DescriptorProtos.FileDescriptorSet.Builder dsBuild = DescriptorProtos.FileDescriptorSet.newBuilder();
+            PluginProtos.CodeGeneratorRequest.Builder reqBuild = PluginProtos.CodeGeneratorRequest.newBuilder();
+
+            GrpcZeroCodeGen codegen = new GrpcZeroCodeGen();
+            assertDoesNotThrow(() -> codegen.processProtoFiles(protoFiles, protoDirs, protobuf, dsBuild, reqBuild));
+
+            assertEquals(1, reqBuild.getFileToGenerateCount(),
+                    "Identical duplicate should be deduped to a single file_to_generate entry");
+        }
+    }
+}

--- a/codegen/src/test/java/io/quarkiverse/grpc/codegen/ProtoTypeConflictDetectorTest.java
+++ b/codegen/src/test/java/io/quarkiverse/grpc/codegen/ProtoTypeConflictDetectorTest.java
@@ -1,0 +1,126 @@
+package io.quarkiverse.grpc.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.protobuf.DescriptorProtos;
+
+import io.quarkus.bootstrap.prebuild.CodeGenException;
+
+class ProtoTypeConflictDetectorTest {
+
+    private static DescriptorProtos.FileDescriptorSet buildDescriptorSet(String pkg, String messageName,
+            DescriptorProtos.FieldDescriptorProto.Type fieldType) {
+        return DescriptorProtos.FileDescriptorSet.newBuilder()
+                .addFile(DescriptorProtos.FileDescriptorProto.newBuilder()
+                        .setName("test.proto")
+                        .setPackage(pkg)
+                        .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                                .setName(messageName)
+                                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                                        .setName("value")
+                                        .setNumber(1)
+                                        .setType(fieldType)
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    @Test
+    void identicalTypesAreTreatedAsDuplicates() throws Exception {
+        ProtoTypeConflictDetector detector = new ProtoTypeConflictDetector();
+
+        var set = buildDescriptorSet("demo", "Foo", DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING);
+
+        boolean firstResult = detector.checkAndRecord(set, "source-a.proto");
+        boolean secondResult = detector.checkAndRecord(set, "source-b.proto");
+
+        assertTrue(!firstResult, "First encounter should not be a duplicate");
+        assertTrue(secondResult, "Second encounter with identical bytes should be a duplicate");
+    }
+
+    @Test
+    void conflictingTypesThrowCodeGenException() {
+        ProtoTypeConflictDetector detector = new ProtoTypeConflictDetector();
+
+        var stringVersion = buildDescriptorSet("demo", "Foo", DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING);
+        var intVersion = buildDescriptorSet("demo", "Foo", DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32);
+
+        assertDoesNotThrow(() -> detector.checkAndRecord(stringVersion, "first.proto"));
+
+        CodeGenException ex = assertThrows(CodeGenException.class,
+                () -> detector.checkAndRecord(intVersion, "second.proto"));
+
+        assertTrue(ex.getMessage().contains(".demo.Foo"),
+                "Should name the conflicting FQN, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("first.proto"),
+                "Should name the first source, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("second.proto"),
+                "Should name the second source, got: " + ex.getMessage());
+    }
+
+    @Test
+    void differentFqnsDoNotConflict() throws Exception {
+        ProtoTypeConflictDetector detector = new ProtoTypeConflictDetector();
+
+        var fooSet = buildDescriptorSet("pkg.a", "Foo", DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING);
+        var barSet = buildDescriptorSet("pkg.b", "Bar", DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32);
+
+        boolean first = detector.checkAndRecord(fooSet, "a.proto");
+        boolean second = detector.checkAndRecord(barSet, "b.proto");
+
+        assertTrue(!first, "First type should not be a duplicate");
+        assertTrue(!second, "Different FQN should not be a duplicate");
+    }
+
+    @Test
+    void nestedTypesAreChecked() {
+        ProtoTypeConflictDetector detector = new ProtoTypeConflictDetector();
+
+        DescriptorProtos.FileDescriptorSet setA = DescriptorProtos.FileDescriptorSet.newBuilder()
+                .addFile(DescriptorProtos.FileDescriptorProto.newBuilder()
+                        .setName("a.proto")
+                        .setPackage("outer")
+                        .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                                .setName("Parent")
+                                .addNestedType(DescriptorProtos.DescriptorProto.newBuilder()
+                                        .setName("Child")
+                                        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                                                .setName("x").setNumber(1)
+                                                .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        DescriptorProtos.FileDescriptorSet setB = DescriptorProtos.FileDescriptorSet.newBuilder()
+                .addFile(DescriptorProtos.FileDescriptorProto.newBuilder()
+                        .setName("b.proto")
+                        .setPackage("outer")
+                        .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                                .setName("Parent")
+                                .addNestedType(DescriptorProtos.DescriptorProto.newBuilder()
+                                        .setName("Child")
+                                        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                                                .setName("x").setNumber(1)
+                                                .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32)
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        assertDoesNotThrow(() -> detector.checkAndRecord(setA, "a.proto"));
+        CodeGenException ex = assertThrows(CodeGenException.class,
+                () -> detector.checkAndRecord(setB, "b.proto"));
+
+        assertTrue(ex.getMessage().contains(".outer.Parent"),
+                "Should identify the conflict at the parent level (which includes nested types), got: "
+                        + ex.getMessage());
+    }
+}


### PR DESCRIPTION
# Detect duplicate proto types by descriptor FQN

## Why

When a project pulls proto files from multiple sources (src/main/proto, scanned dependencies, external registries, shared git repositories, vendored copies) it becomes easy to accidentally bring in two versions of the same proto. Today the plugin happily accepts this without a word. The resulting class files depend entirely on which version protoc happened to see first, and any divergence surfaces later as:

- Non-deterministic generated code between builds
- Field number conflicts that compile cleanly but explode at runtime
- Incompatible message shapes that silently break wire-level interop

Catching this at build time, with a clear error that names the conflicting type and both sources, is strictly safer than letting it slide.

## What this PR does

Adds a small `ProtoTypeConflictDetector` that walks the `FileDescriptorProto` returned by `protobuf.getDescriptors(...)` for each proto file and tracks every message, enum, and service by its protobuf fully qualified name. On a repeat FQN it compares the raw `DescriptorProto` / `EnumDescriptorProto` / `ServiceDescriptorProto` bytes:

- **Identical bytes**: logged at `info` level and deduped. Two sources shipping the same proto is benign.
- **Different bytes**: throws a `CodeGenException` naming the FQN and both source files. Build stops immediately with a message you can act on.

### Why compare descriptor bytes, not source text

Descriptor comparison is immune to the things that don't matter:

- **Comments**: not part of `DescriptorProto`, so documentation edits never trip a false positive.
- **Whitespace and formatting**: the parser throws them away.
- **Import ordering**: lives on the `FileDescriptorProto` wrapper, not on the per-type descriptors we compare.
- **File-level options** like `java_package` and `java_multiple_files`: live in `FileOptions`, also outside the comparison.

Two teams with the same proto reformatted differently, with different comments, in different import orders, still match.

The only case that produces a mismatch on semantically-equivalent input is reordering fields in the source (since protoc preserves declaration order in the descriptor). That's arguably a real change worth flagging.

## How the code is organized

- `ProtoTypeConflictDetector` is a dedicated class with the state (`seenTypeBytes`, `seenTypeSource`) as instance fields and one public entry point: `checkAndRecord(FileDescriptorSet, String sourceProtoFile)`. It has no dependency on `GrpcZeroCodeGen`, `ZeroFs`, or `Protobuf`. It just walks descriptors, which makes it cheap and isolated to unit-test.
- The inline proto loop in `trigger()` is extracted into a new package-private `processProtoFiles` method that owns the detector and tracks which `protoName` values have already been registered for generation.
- Default behavior is unchanged when every proto file is unique: the detector records each type once, returns `false` (not a duplicate), and the original flow continues.

## Bundled cleanups

While I was in the same method, a few incidental fixes hitched a ride:

- Extracted `loadDescriptorSet` helper so the try/catch around `protobuf.getDescriptors(...)` doesn't clutter `processProtoFiles`.
- Removed an unused `workdir` parameter from `processProtoFiles`. The per-file `Files.copy` that used it was redundant (the earlier `copyDirectory` step already places files at their correct relative paths) and used `getFileName()` in a way that would overwrite files with the same basename.
- Dropped a dead `Protobuf` parameter from `resolveDependencies`.
- Fixed `protobuf.buildFileDescriptors(...)` (static method called via instance reference) to `Protobuf.buildFileDescriptors(...)`.
- Removed a redundant cast on `Files.getFileAttributeView(...)`. The method is generically typed.
- Fixed the `realitivizeProtoFile` typo on the helper being rewritten and simplified its body.

Happy to split any of these into a separate cleanup PR if you'd prefer this change to stay strictly focused on the dedup logic.

## Tests

- `ProtoTypeConflictDetectorTest`: 4 fast unit tests that build `FileDescriptorProto` programmatically and exercise the detector directly. Covers benign duplicates, conflicting FQNs, unrelated FQNs, and nested message conflicts.
- `ProcessProtoFilesTest`: 3 integration-style tests that write real `.proto` files and drive `processProtoFiles` through a real `Protobuf` instance on `ZeroFs`. Covers multiple protos with distinct FQNs, conflicting FQNs across files, and an identical proto contributed by two separate source directories.

All existing codegen and `hello-world` integration tests remain green.

## Backward compatibility

No public API changes. No configuration changes. When proto files are unique, the added work is one descriptor walk per file and a pair of map lookups per declared type, negligible compared to the protoc invocation it follows.
