### PR TITLE
feat(codegen): input-hash cache to skip codegen when proto inputs are unchanged

### DIFF
--- a/codegen/src/main/java/io/quarkiverse/grpc/codegen/GrpcZeroCodeGen.java
+++ b/codegen/src/main/java/io/quarkiverse/grpc/codegen/GrpcZeroCodeGen.java
@@ -6,6 +6,7 @@ import static java.lang.Boolean.TRUE;
 import static java.nio.file.Files.copy;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -17,17 +18,21 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.HexFormat;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -72,6 +77,22 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
     private static final String DESCRIPTOR_SET_FILENAME = "quarkus.generate-code.grpc.descriptor-set.name";
 
     private static final String GENERATE_KOTLIN = "quarkus.generate-code.grpc.kotlin.generate";
+
+    // Output-resident marker holding the hash of the last successful codegen inputs.
+    // Lives in outDir so it shares the generated sources' lifecycle (a `clean` wipes both).
+    private static final String CODEGEN_CACHE_MARKER = ".grpc-zero-inputs.sha256";
+    // Config keys whose values change generated output; folded into the cache key.
+    // GENERATE_KOTLIN is deliberately absent: Kotlin generation can be driven by the presence of
+    // the quarkus-kotlin dependency when the config is unset, so the *effective* decision
+    // (shouldGenerateKotlin) is hashed instead of the raw config value.
+    private static final String[] CACHE_RELEVANT_CONFIG_KEYS = {
+            GENERATE_DESCRIPTOR_SET,
+            DESCRIPTOR_SET_OUTPUT_DIR,
+            DESCRIPTOR_SET_FILENAME,
+            POST_PROCESS_SKIP,
+            SCAN_DEPENDENCIES_FOR_PROTO,
+            SCAN_FOR_IMPORTS,
+    };
 
     private String input;
     private boolean hasQuarkusKotlinDependency;
@@ -153,6 +174,28 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
             Collection<String> protosToImport = gatherDirectoriesWithImports(workDir.resolve("protoc-dependencies"),
                     context);
 
+            // Input-hash cache: skip the (slow) WASM codegen when the proto set, the
+            // output-affecting config and the grpc-zero version are all unchanged and
+            // the previously generated output is still present.
+            String inputHash = computeInputHash(protoFiles, protoDirs, protosToImport, context.config());
+            Path cacheMarker = outDir.resolve(CODEGEN_CACHE_MARKER);
+            boolean descriptorRequired = shouldGenerateDescriptorSet(context.config());
+            Path descriptorFile = null;
+            if (descriptorRequired) {
+                try {
+                    descriptorFile = getDescriptorSetOutputFile(context);
+                } catch (IOException e) {
+                    // Cannot resolve the descriptor target -> cannot prove the cache is valid; regenerate.
+                    // The real descriptor write below re-throws if this is a genuine I/O problem.
+                    log.debugf(e, "Grpc Zero: could not resolve descriptor target for cache check; will regenerate");
+                    descriptorFile = null;
+                }
+            }
+            if (isUpToDate(inputHash, cacheMarker, outDir, descriptorRequired, descriptorFile)) {
+                log.info("Grpc Zero: proto inputs and config unchanged - skipping code generation (cache hit)");
+                return true;
+            }
+
             try (FileSystem fs = ZeroFs.newFileSystem(
                     Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
                 var workdir = fs.getPath(".");
@@ -231,6 +274,7 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
                 postprocessing(context, outDir);
                 log.info("Grpc Zero: Successfully finished generating and post-processing sources from proto files");
 
+                writeCacheMarker(cacheMarker, inputHash);
                 return true;
             } catch (IOException e) {
                 throw new CodeGenException("Failed to generate files from proto file in " + inputDir.toAbsolutePath(), e);
@@ -238,6 +282,106 @@ public class GrpcZeroCodeGen implements CodeGenProvider {
         }
 
         return false;
+    }
+
+    /**
+     * Computes a content hash over everything that influences generated output: the compiled
+     * proto files, the imported proto files, the output-affecting config options and the
+     * grpc-zero version. Used to skip regeneration when nothing has changed.
+     *
+     * <p>
+     * Each proto contributes its <em>import-relative</em> name (the path protoc sees, relative
+     * to its proto root) plus its content. The relative name matters because it lands in the
+     * generated {@code FileDescriptorProto.name} and drives the Java output layout, so a
+     * move/rename within the tree must invalidate the cache even when the bytes are identical.
+     */
+    // Package-private for unit testing.
+    String computeInputHash(List<String> protoFiles, Set<String> protoDirs, Collection<String> importDirs, Config config)
+            throws CodeGenException {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            String version = GrpcZeroCodeGen.class.getPackage().getImplementationVersion();
+            md.update(("grpc-zero\0" + (version == null ? "dev" : version)).getBytes(StandardCharsets.UTF_8));
+            for (String key : CACHE_RELEVANT_CONFIG_KEYS) {
+                md.update(key.getBytes(StandardCharsets.UTF_8));
+                md.update((byte) 0);
+                md.update(config.getOptionalValue(key, String.class).orElse("").getBytes(StandardCharsets.UTF_8));
+                md.update((byte) 0);
+            }
+            // Effective Kotlin decision (config OR the quarkus-kotlin dependency), so toggling the
+            // dependency without setting the config still invalidates the cache.
+            md.update(("kotlin\0" + shouldGenerateKotlin(config)).getBytes(StandardCharsets.UTF_8));
+            md.update((byte) 0);
+            // Every proto that affects output (compiled + imported), mapped to the import-relative
+            // name protoc will see. Ordered by absolute path for a deterministic digest.
+            TreeMap<Path, String> protos = new TreeMap<>();
+            for (String f : protoFiles) {
+                protos.put(Path.of(f).toAbsolutePath().normalize(), relativizeProtoFile(f, protoDirs));
+            }
+            for (String dir : importDirs) {
+                Path d = Path.of(dir).toAbsolutePath().normalize();
+                if (Files.isDirectory(d)) {
+                    try (Stream<Path> walk = Files.walk(d)) {
+                        walk.filter(Files::isRegularFile)
+                                .filter(p -> p.toString().endsWith(PROTO))
+                                .forEach(p -> {
+                                    Path abs = p.toAbsolutePath().normalize();
+                                    protos.put(abs, d.relativize(abs).toString().replace("\\", "/"));
+                                });
+                    }
+                }
+            }
+            for (Map.Entry<Path, String> entry : protos.entrySet()) {
+                // import-relative name (path-sensitive) + content
+                md.update(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                md.update((byte) 0);
+                md.update(Files.readAllBytes(entry.getKey()));
+                md.update((byte) 0);
+            }
+            return HexFormat.of().formatHex(md.digest());
+        } catch (NoSuchAlgorithmException | IOException e) {
+            throw new CodeGenException("Failed to compute grpc-zero codegen input hash", e);
+        }
+    }
+
+    /**
+     * Returns true when a prior run with the same input hash is still valid: the marker matches,
+     * generated sources are still present, and (when a descriptor set was requested) it still
+     * exists on disk.
+     *
+     * @param descriptorRequired whether descriptor-set generation is enabled for this build
+     * @param descriptorFile the resolved descriptor target, or {@code null} when it could not
+     *        be resolved (treated as "not present" so the build regenerates)
+     */
+    // Package-private for unit testing.
+    boolean isUpToDate(String inputHash, Path cacheMarker, Path outDir, boolean descriptorRequired, Path descriptorFile) {
+        try {
+            if (!Files.isRegularFile(cacheMarker) || !inputHash.equals(Files.readString(cacheMarker).strip())) {
+                return false;
+            }
+            boolean hasGeneratedJava;
+            try (Stream<Path> walk = Files.walk(outDir)) {
+                hasGeneratedJava = walk.anyMatch(p -> p.toString().endsWith(".java"));
+            }
+            if (!hasGeneratedJava) {
+                return false;
+            }
+            return !descriptorRequired || (descriptorFile != null && Files.isRegularFile(descriptorFile));
+        } catch (IOException e) {
+            // Any uncertainty -> regenerate (the safe direction).
+            log.debugf(e, "Grpc Zero: cache up-to-date check failed; will regenerate");
+            return false;
+        }
+    }
+
+    private void writeCacheMarker(Path cacheMarker, String inputHash) {
+        try {
+            Files.createDirectories(cacheMarker.getParent());
+            Files.writeString(cacheMarker, inputHash);
+        } catch (IOException e) {
+            // Caching is best-effort; a marker write failure must never fail the build.
+            log.debugf(e, "Grpc Zero: failed to write codegen cache marker at %s", cacheMarker);
+        }
     }
 
     void processProtoFiles(List<String> protoFiles, Set<String> protoDirs,

--- a/codegen/src/test/java/io/quarkiverse/grpc/codegen/GrpcZeroCodeGenCacheTest.java
+++ b/codegen/src/test/java/io/quarkiverse/grpc/codegen/GrpcZeroCodeGenCacheTest.java
@@ -1,0 +1,207 @@
+package io.quarkiverse.grpc.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+/**
+ * Unit tests for the codegen cache: the input-hash key ({@link GrpcZeroCodeGen#computeInputHash})
+ * and the up-to-date gate ({@link GrpcZeroCodeGen#isUpToDate}).
+ *
+ * <p>
+ * A bug in the key means either stale output (never invalidates) or no caching (never hits),
+ * so it must be stable for identical inputs and change for any output-affecting input. A bug in
+ * the gate means the build trusts a marker even when the generated sources are gone.
+ */
+class GrpcZeroCodeGenCacheTest {
+
+    @TempDir
+    Path tempDir;
+
+    private final GrpcZeroCodeGen codegen = new GrpcZeroCodeGen();
+
+    private static final String PROTO_A = "syntax = \"proto3\";\npackage p.a;\nmessage A { string x = 1; }\n";
+
+    private Path protoRoot() throws Exception {
+        Path dir = tempDir.resolve("protos");
+        Files.createDirectories(dir);
+        return dir;
+    }
+
+    /** Writes a proto under the shared proto root, creating intermediate dirs, and returns its absolute path. */
+    private Path writeProto(String relativePath, String content) throws Exception {
+        Path p = protoRoot().resolve(relativePath);
+        Files.createDirectories(p.getParent());
+        Files.writeString(p, content, StandardCharsets.UTF_8);
+        return p.toAbsolutePath();
+    }
+
+    private Set<String> roots() throws Exception {
+        return Set.of(protoRoot().toAbsolutePath().toString());
+    }
+
+    private static Config config(String... keyValues) {
+        SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
+        for (int i = 0; i + 1 < keyValues.length; i += 2) {
+            builder.withDefaultValue(keyValues[i], keyValues[i + 1]);
+        }
+        return builder.build();
+    }
+
+    // ---- computeInputHash ------------------------------------------------------------------
+
+    @Test
+    void identicalInputsProduceIdenticalHash() throws Exception {
+        List<String> protos = List.of(writeProto("a.proto", PROTO_A).toString());
+        assertEquals(
+                codegen.computeInputHash(protos, roots(), List.of(), config()),
+                codegen.computeInputHash(protos, roots(), List.of(), config()),
+                "Identical protos + config must hash identically, otherwise the cache could never hit");
+    }
+
+    @Test
+    void editingProtoContentChangesHash() throws Exception {
+        Path a = writeProto("a.proto", PROTO_A);
+        String before = codegen.computeInputHash(List.of(a.toString()), roots(), List.of(), config());
+
+        Files.writeString(a, PROTO_A.replace("string x = 1;", "string x = 1;\n  int32 y = 2;"), StandardCharsets.UTF_8);
+        String after = codegen.computeInputHash(List.of(a.toString()), roots(), List.of(), config());
+
+        assertNotEquals(before, after, "Editing a proto's content must invalidate the cache");
+    }
+
+    @Test
+    void addingProtoChangesHash() throws Exception {
+        Path a = writeProto("a.proto", PROTO_A);
+        String oneFile = codegen.computeInputHash(List.of(a.toString()), roots(), List.of(), config());
+
+        Path b = writeProto("b.proto", "syntax = \"proto3\";\npackage p.b;\nmessage B { string y = 1; }\n");
+        String twoFiles = codegen.computeInputHash(List.of(a.toString(), b.toString()), roots(), List.of(), config());
+
+        assertNotEquals(oneFile, twoFiles, "Adding a proto must invalidate the cache");
+    }
+
+    @Test
+    void movingProtoWithIdenticalContentChangesHash() throws Exception {
+        // Same bytes, different import-relative path. The relative name lands in the generated
+        // descriptor and Java layout, so the move MUST invalidate even though content is identical.
+        Path atA = writeProto("a/foo.proto", PROTO_A);
+        String hashA = codegen.computeInputHash(List.of(atA.toString()), roots(), List.of(), config());
+
+        Path atB = writeProto("b/foo.proto", PROTO_A);
+        String hashB = codegen.computeInputHash(List.of(atB.toString()), roots(), List.of(), config());
+
+        assertNotEquals(hashA, hashB,
+                "Moving a proto to a different import path must invalidate the cache even with identical content");
+    }
+
+    @Test
+    void changingOutputAffectingConfigChangesHash() throws Exception {
+        List<String> protos = List.of(writeProto("a.proto", PROTO_A).toString());
+        String defaults = codegen.computeInputHash(protos, roots(), List.of(), config());
+        String kotlinEnabled = codegen.computeInputHash(protos, roots(), List.of(),
+                config("quarkus.generate-code.grpc.kotlin.generate", "true"));
+
+        assertNotEquals(defaults, kotlinEnabled, "An output-affecting config change must invalidate the cache");
+    }
+
+    @Test
+    void editingAnImportedProtoChangesHash() throws Exception {
+        List<String> protos = List.of(writeProto("a.proto", PROTO_A).toString());
+
+        Path importDir = tempDir.resolve("imports");
+        Files.createDirectories(importDir);
+        Path imported = importDir.resolve("dep.proto");
+        Files.writeString(imported, "syntax = \"proto3\";\npackage dep;\nmessage Dep { string z = 1; }\n");
+        List<String> importDirs = List.of(importDir.toAbsolutePath().toString());
+
+        String before = codegen.computeInputHash(protos, roots(), importDirs, config());
+        Files.writeString(imported, "syntax = \"proto3\";\npackage dep;\nmessage Dep { string z = 1; int32 w = 2; }\n");
+        String after = codegen.computeInputHash(protos, roots(), importDirs, config());
+
+        assertNotEquals(before, after, "Editing an imported proto must invalidate the cache");
+    }
+
+    // ---- isUpToDate ------------------------------------------------------------------------
+
+    private static final String HASH = "deadbeef";
+
+    /** Lays out an outDir with a cache marker and (optionally) a generated .java file. */
+    private Path outDirWith(String markerContent, boolean withJava) throws Exception {
+        Path outDir = tempDir.resolve("out");
+        Files.createDirectories(outDir);
+        if (markerContent != null) {
+            Files.writeString(outDir.resolve(".grpc-zero-inputs.sha256"), markerContent);
+        }
+        if (withJava) {
+            Files.writeString(outDir.resolve("Generated.java"), "class Generated {}");
+        }
+        return outDir;
+    }
+
+    @Test
+    void upToDateWhenMarkerMatchesAndSourcesPresent() throws Exception {
+        Path outDir = outDirWith(HASH, true);
+        assertTrue(codegen.isUpToDate(HASH, outDir.resolve(".grpc-zero-inputs.sha256"), outDir, false, null),
+                "Matching marker + generated sources present is a valid cache hit");
+    }
+
+    @Test
+    void staleWhenMarkerMissing() throws Exception {
+        Path outDir = outDirWith(null, true);
+        assertFalse(codegen.isUpToDate(HASH, outDir.resolve(".grpc-zero-inputs.sha256"), outDir, false, null),
+                "A missing marker is never a cache hit");
+    }
+
+    @Test
+    void staleWhenHashDiffers() throws Exception {
+        Path outDir = outDirWith("an-older-hash", true);
+        assertFalse(codegen.isUpToDate(HASH, outDir.resolve(".grpc-zero-inputs.sha256"), outDir, false, null),
+                "A marker from a different input set must not hit");
+    }
+
+    @Test
+    void staleWhenNoGeneratedSources() throws Exception {
+        // Marker matches but the generated sources were wiped (e.g. partial clean): regenerate.
+        Path outDir = outDirWith(HASH, false);
+        assertFalse(codegen.isUpToDate(HASH, outDir.resolve(".grpc-zero-inputs.sha256"), outDir, false, null),
+                "A matching marker with no .java on disk must not hit");
+    }
+
+    @Test
+    void staleWhenDescriptorRequiredButMissing() throws Exception {
+        Path outDir = outDirWith(HASH, true);
+        Path descriptor = outDir.resolve("services.dsc"); // never created
+        assertFalse(codegen.isUpToDate(HASH, outDir.resolve(".grpc-zero-inputs.sha256"), outDir, true, descriptor),
+                "When a descriptor set is requested but absent, the cache must not hit");
+    }
+
+    @Test
+    void upToDateWhenDescriptorRequiredAndPresent() throws Exception {
+        Path outDir = outDirWith(HASH, true);
+        Path descriptor = outDir.resolve("services.dsc");
+        Files.writeString(descriptor, "dsc");
+        assertTrue(codegen.isUpToDate(HASH, outDir.resolve(".grpc-zero-inputs.sha256"), outDir, true, descriptor),
+                "Requested descriptor present on disk is a valid cache hit");
+    }
+
+    @Test
+    void staleWhenDescriptorRequiredButUnresolved() throws Exception {
+        Path outDir = outDirWith(HASH, true);
+        assertFalse(codegen.isUpToDate(HASH, outDir.resolve(".grpc-zero-inputs.sha256"), outDir, true, null),
+                "An unresolved descriptor target (null) must not hit when a descriptor was requested");
+    }
+}

--- a/codegen/src/test/java/io/quarkiverse/grpc/codegen/ProcessProtoFilesTest.java
+++ b/codegen/src/test/java/io/quarkiverse/grpc/codegen/ProcessProtoFilesTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.grpc.codegen;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,6 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,6 +35,29 @@ class ProcessProtoFilesTest {
     private void writeProto(Path dir, String filename, String content) throws Exception {
         Files.createDirectories(dir);
         Files.writeString(dir.resolve(filename), content, StandardCharsets.UTF_8);
+    }
+
+    private PluginProtos.CodeGeneratorRequest buildRequest(List<String> protoFiles, Set<String> protoDirs) throws Exception {
+        try (FileSystem fs = ZeroFs.newFileSystem(
+                Configuration.unix().toBuilder().setAttributeViews("unix").build())) {
+            Path workdir = fs.getPath(".");
+            for (String dir : protoDirs) {
+                GrpcZeroCodeGen.copyDirectory(Path.of(dir), workdir);
+            }
+            Protobuf protobuf = Protobuf.builder().withWorkdir(workdir).build();
+
+            DescriptorProtos.FileDescriptorSet.Builder dsBuild = DescriptorProtos.FileDescriptorSet.newBuilder();
+            PluginProtos.CodeGeneratorRequest.Builder reqBuild = PluginProtos.CodeGeneratorRequest.newBuilder();
+
+            GrpcZeroCodeGen codegen = new GrpcZeroCodeGen();
+            codegen.processProtoFiles(protoFiles, protoDirs, protobuf, dsBuild, reqBuild);
+            return reqBuild.build();
+        }
+    }
+
+    private static String sha256(PluginProtos.CodeGeneratorRequest request) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(request.toByteArray());
+        return HexFormat.of().formatHex(digest);
     }
 
     @Test
@@ -131,5 +157,56 @@ class ProcessProtoFilesTest {
             assertEquals(1, reqBuild.getFileToGenerateCount(),
                     "Identical duplicate should be deduped to a single file_to_generate entry");
         }
+    }
+
+    @Test
+    void protoRemovalChangesRequestHash() throws Exception {
+        Path protoDir = tempDir.resolve("protos");
+        writeProto(protoDir, "a.proto",
+                "syntax = \"proto3\";\npackage p.a;\nmessage A { string x = 1; }\n");
+        writeProto(protoDir, "b.proto",
+                "syntax = \"proto3\";\npackage p.b;\nmessage B { string y = 1; }\n");
+
+        String a = protoDir.resolve("a.proto").toAbsolutePath().toString();
+        String b = protoDir.resolve("b.proto").toAbsolutePath().toString();
+        Set<String> protoDirs = new LinkedHashSet<>(List.of(protoDir.toAbsolutePath().toString()));
+
+        PluginProtos.CodeGeneratorRequest twoProtoRequest = buildRequest(List.of(a, b), protoDirs);
+        PluginProtos.CodeGeneratorRequest oneProtoRequest = buildRequest(List.of(a), protoDirs);
+
+        assertNotEquals(sha256(twoProtoRequest), sha256(oneProtoRequest),
+                "Removing a proto must change the computed request hash");
+    }
+
+    @Test
+    void importDirectoryAddedOrRemovedChangesResolutionOutcome() throws Exception {
+        Path mainDir = tempDir.resolve("main");
+        Path importDir = tempDir.resolve("imports");
+
+        writeProto(mainDir, "main.proto",
+                """
+                        syntax = "proto3";
+                        package mainpkg;
+                        import "dep.proto";
+                        message Main { depkg.Dep dep = 1; }
+                        """);
+        writeProto(importDir, "dep.proto",
+                """
+                        syntax = "proto3";
+                        package depkg;
+                        message Dep { string value = 1; }
+                        """);
+
+        String mainProto = mainDir.resolve("main.proto").toAbsolutePath().toString();
+
+        Set<String> withImportDirectory = new LinkedHashSet<>(List.of(
+                mainDir.toAbsolutePath().toString(),
+                importDir.toAbsolutePath().toString()));
+        assertDoesNotThrow(() -> buildRequest(List.of(mainProto), withImportDirectory),
+                "Adding the import directory should make transitive imports resolvable");
+
+        Set<String> withoutImportDirectory = new LinkedHashSet<>(List.of(mainDir.toAbsolutePath().toString()));
+        assertThrows(CodeGenException.class, () -> buildRequest(List.of(mainProto), withoutImportDirectory),
+                "Removing the import directory should break transitive import resolution");
     }
 }


### PR DESCRIPTION
## Why

`GrpcZeroCodeGen` is a build-tool-agnostic `CodeGenProvider`, which has no
up-to-date contract — so `trigger()` runs the cold WASM protoc passes
(JAVA + GRPC_JAVA, plus Mutiny/Kotlin/descriptor) on **every** build, even when
nothing about the protos changed. On CI this cost is re-paid by each job that
builds the module. A native Gradle task or Maven mojo would get incrementality
for free; since codegen runs through the `CodeGenProvider` model, the skip logic
has to live inside `trigger()`.

## What

- Compute a SHA-256 over everything that affects generated output:
  - the grpc-zero version,
  - the output-affecting config (descriptor-set options, post-processing skip,
    scan-for-proto / scan-for-imports),
  - the **effective** Kotlin decision (config *or* the `quarkus-kotlin`
    dependency), and
  - every proto that affects output (compiled **and** imported), each hashed by
    its **import-relative name + content**.
- Persist it to `.grpc-zero-inputs.sha256` inside `outDir`, so the marker shares
  the generated sources' lifecycle — a `clean` wipes both and forces regen.
- Skip codegen when the marker matches, generated sources are still present, and
  (when requested) the descriptor set still exists on disk.

The gate fails safe: any uncertainty (missing/mismatched marker, missing
output, I/O error) falls back to regenerating. The marker write is best-effort
and never fails the build.

### Correctness notes

- The cache key uses each proto's **import-relative path**, not its bare
  filename — that path lands in `FileDescriptorProto.name` and drives the Java
  output layout, so a move/rename within the tree invalidates even when the
  bytes are identical.
- The **effective** Kotlin decision is hashed (not the raw config), so toggling
  the `quarkus-kotlin` dependency without setting
  `quarkus.generate-code.grpc.kotlin.generate` still invalidates.

## Tests

13 unit tests covering the key (stability, content edit, add, move-with-
identical-content, output-affecting config, imported-proto edit) and the gate
(marker match/missing/mismatch, missing sources, descriptor
required+present/missing/unresolved). Full `codegen` module suite green.

Verified on the `hello-world` integration test: warm rebuild skips codegen
(~2.9s → ~0.5s) and regenerates correctly after a proto edit.

## Out of scope

Codegen does not currently prune orphaned output when a proto is deleted; a
stale generated `.java` can linger until `clean`. Left as a follow-up to keep
this change focused.
